### PR TITLE
Fix RSA key attestation

### DIFF
--- a/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeViewModel.kt
@@ -41,7 +41,7 @@ class HomeViewModel(
         }
     }
 
-    private val attestationRepository = AttestationRepository(KeyStoreKeyType.ECDSA)
+    private val attestationRepository = AttestationRepository()
     private val attestationData = MutableLiveData<Resource<BaseData>>()
 
     var secretMode = sp.getBoolean("secret_mode", true)

--- a/app/src/main/java/io/github/vvb2060/keyattestation/repository/AttestationRepository.java
+++ b/app/src/main/java/io/github/vvb2060/keyattestation/repository/AttestationRepository.java
@@ -41,8 +41,8 @@ public class AttestationRepository {
     private final List<X509Certificate> currentCerts;
     private IAndroidKeyStore keyStore;
 
-    public AttestationRepository(byte keyStoreKeyType) throws Exception {
-        localKeyStore = new AndroidKeyStore(keyStoreKeyType);
+    public AttestationRepository() throws Exception {
+        localKeyStore = new AndroidKeyStore();
         factory = CertificateFactory.getInstance("X.509");
         currentCerts = new ArrayList<>();
         keyStore = localKeyStore;


### PR DESCRIPTION
At present KAD doesn't use an RSA `KeyPairGenerator` when in RSA mode and the ECDSA key type is [hardcoded](https://github.com/VisionR1/KeyAttestation/blob/9441ecb44a5d214a30a37b6d09b6700936950594/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeViewModel.kt#L44).

This change removes the key type specialisation from the constructors of the `AttestationRepository` and `AndroidKeyStore` classes and moves key type handling into the `generateKeyPair()` method, which already has the key type byte passed as a parameter.

`AndroidKeyStore` now initialises both ECDSA and RSA `KeyPairGenerator` instances at construction and selects the correct one in `generateKeyPair()` using the `keyStoreKeyType` parameter.