### PR TITLE
Refactor CRL UI, clean up certificate chain, and optimize network fetches

### DIFF
--- a/app/src/main/java/io/github/vvb2060/keyattestation/attestation/CertificateInfo.java
+++ b/app/src/main/java/io/github/vvb2060/keyattestation/attestation/CertificateInfo.java
@@ -68,11 +68,14 @@ public class CertificateInfo {
         try {
             status = CERT_SIGN;
             cert.verify(parentKey);
+            
             status = CERT_REVOKED;
             var certStatus = RevocationList.get(cert.getSerialNumber());
             if (certStatus != null) {
-                throw new CertificateException("Certificate revocation " + certStatus);
+                // Just throw the status message (e.g., "REVOKED") without any suffix
+                throw new CertificateException(certStatus.status());
             }
+            
             status = CERT_EXPIRED;
             cert.checkValidity();
             status = CERT_NORMAL;
@@ -86,11 +89,6 @@ public class CertificateInfo {
         boolean terminate;
         try {
             attestation = Attestation.loadFromCertificate(cert);
-            // If key purpose included KeyPurpose::SIGN,
-            // then it could be used to sign arbitrary data, including any tbsCertificate,
-            // and so an attestation produced by the key would have no security properties.
-            // If the parent certificate can attest that the key purpose is only KeyPurpose::ATTEST_KEY,
-            // then the child certificate can be trusted.
             var purposes = attestation.getTeeEnforced().getPurposes();
             terminate = purposes == null || !purposes.contains(AuthorizationList.KM_PURPOSE_ATTEST_KEY);
         } catch (CertificateParsingException e) {

--- a/app/src/main/java/io/github/vvb2060/keyattestation/attestation/RevocationList.java
+++ b/app/src/main/java/io/github/vvb2060/keyattestation/attestation/RevocationList.java
@@ -20,13 +20,25 @@ import java.util.Locale;
 import io.github.vvb2060.keyattestation.AppApplication;
 import io.github.vvb2060.keyattestation.R;
 
-public record RevocationList(String status, String reason) {
+public record RevocationList(String status, String reason, DataSource source) {
+    public enum DataSource {
+        NETWORK_UPDATE,
+        NETWORK_UP_TO_DATE,
+        CACHE,
+        BUNDLED
+    }
+
     private static final String TAG = "RevocationList";
     private static final String CACHE_FILE = "revocation_cache.json";
     private static final String PREFS_NAME = "revocation_prefs";
     private static final String KEY_PUBLISH_TIME = "last_publish_time";
+    
     private static JSONObject data = null;
     private static Date publishTime = null;
+    private static DataSource currentSource = DataSource.BUNDLED;
+
+    private record StatusResult(JSONObject json, DataSource source) {}
+    private record NetworkResult(JSONObject json, int responseCode) {}
 
     private static String toString(InputStream input) throws IOException {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -43,16 +55,15 @@ public record RevocationList(String status, String reason) {
 
     private static JSONObject parseStatus(InputStream inputStream) throws IOException {
         try {
-            var statusListJson = new JSONObject(toString(inputStream));
-            return statusListJson.getJSONObject("entries");
+            return new JSONObject(toString(inputStream));
         } catch (JSONException e) {
             throw new IOException(e);
         }
     }
 
-    private static void saveToCache(JSONObject json) {
+    private static void saveToCache(JSONObject fullJson) {
         try (var output = AppApplication.app.openFileOutput(CACHE_FILE, Context.MODE_PRIVATE)) {
-            output.write(json.toString().getBytes(StandardCharsets.UTF_8));
+            output.write(fullJson.toString().getBytes(StandardCharsets.UTF_8));
             if (publishTime != null) {
                 var prefs = AppApplication.app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
                 prefs.edit().putLong(KEY_PUBLISH_TIME, publishTime.getTime()).apply();
@@ -62,7 +73,7 @@ public record RevocationList(String status, String reason) {
         }
     }
 
-    private static JSONObject fetchFromNetwork(String statusUrl) {
+    private static NetworkResult fetchFromNetwork(String statusUrl, long cachedTime) {
         HttpURLConnection connection = null;
         try {
             URL url = new URL(statusUrl);
@@ -72,36 +83,39 @@ public record RevocationList(String status, String reason) {
             connection.setReadTimeout(10000);
             connection.setRequestProperty("User-Agent", "KeyAttestation");
             
+            if (cachedTime != 0) {
+                connection.setIfModifiedSince(cachedTime);
+            }
+            
             int responseCode = connection.getResponseCode();
+            
+            if (responseCode == HttpURLConnection.HTTP_NOT_MODIFIED) {
+                return new NetworkResult(null, responseCode);
+            }
+            
             if (responseCode == HttpURLConnection.HTTP_OK) {
                 long lastModified = connection.getLastModified();
                 if (lastModified != 0) {
                     publishTime = new Date(lastModified);
-                    Log.i(TAG, "Revocation list Last-Modified: " + publishTime);
                 }
                 
                 try (var input = connection.getInputStream()) {
-                    return parseStatus(input);
+                    return new NetworkResult(parseStatus(input), responseCode);
                 }
-            } else {
-                Log.w(TAG, "Failed to fetch revocation list from network, HTTP " + responseCode);
-                return null;
             }
+            return null;
         } catch (Exception e) {
-            Log.w(TAG, "Failed to fetch revocation list from network", e);
+            Log.w(TAG, "Network fetch failed", e);
             return null;
         } finally {
-            if (connection != null) {
-                connection.disconnect();
-            }
+            if (connection != null) connection.disconnect();
         }
     }
 
-    private static JSONObject getStatus() {
+    private static StatusResult getStatus() {
         var statusUrl = "https://android.googleapis.com/attestation/status";
-        var resName = "android:string/vendor_required_attestation_revocation_list_url";
         var res = AppApplication.app.getResources();
-        // noinspection DiscouragedApi
+        var resName = "android:string/vendor_required_attestation_revocation_list_url";
         var id = res.getIdentifier(resName, null, null);
         if (id != 0) {
             var url = res.getString(id);
@@ -109,32 +123,45 @@ public record RevocationList(String status, String reason) {
                 statusUrl = url;
             }
         }
+
+        var prefs = AppApplication.app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        long cachedTime = prefs.getLong(KEY_PUBLISH_TIME, 0);
         
-        // 1. Try Network
-        JSONObject networkData = fetchFromNetwork(statusUrl);
-        if (networkData != null) {
-            Log.i(TAG, "Successfully fetched revocation list from network");
-            saveToCache(networkData);
-            return networkData;
+        // 1. Network Check
+        NetworkResult networkResult = fetchFromNetwork(statusUrl, cachedTime);
+        if (networkResult != null) {
+            if (networkResult.responseCode() == HttpURLConnection.HTTP_NOT_MODIFIED) {
+                try (var fis = AppApplication.app.openFileInput(CACHE_FILE)) {
+                    var cacheJson = parseStatus(fis);
+                    publishTime = new Date(cachedTime);
+                    return new StatusResult(cacheJson.getJSONObject("entries"), DataSource.NETWORK_UP_TO_DATE);
+                } catch (Exception e) {
+                    Log.w(TAG, "Failed to read cache despite 304 response. Falling back.", e);
+                }
+            } else if (networkResult.json() != null) {
+                saveToCache(networkResult.json());
+                try {
+                    return new StatusResult(networkResult.json().getJSONObject("entries"), DataSource.NETWORK_UPDATE);
+                } catch (JSONException ignored) {}
+            }
         }
         
-        // 2. Try Cache (osm0sis fallback)
+        // 2. Cache
         try (var fis = AppApplication.app.openFileInput(CACHE_FILE)) {
-            Log.i(TAG, "Using cached revocation list");
-            var prefs = AppApplication.app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
-            long lastTime = prefs.getLong(KEY_PUBLISH_TIME, 0);
-            if (lastTime != 0) publishTime = new Date(lastTime);
-            return parseStatus(fis);
-        } catch (IOException e) {
-            Log.i(TAG, "No cached revocation list found");
+            var cacheJson = parseStatus(fis);
+            if (cachedTime != 0) publishTime = new Date(cachedTime);
+            return new StatusResult(cacheJson.getJSONObject("entries"), DataSource.CACHE);
+        } catch (Exception e) {
+            Log.i(TAG, "Cache unavailable");
         }
 
-        // 3. Fallback to bundled resource
-        Log.i(TAG, "Using bundled revocation list");
+        // 3. Bundled
         try (var input = res.openRawResource(R.raw.status)) {
-            return parseStatus(input);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to parse certificate revocation status", e);
+            var bundledJson = parseStatus(input);
+            publishTime = null; 
+            return new StatusResult(bundledJson.getJSONObject("entries"), DataSource.BUNDLED);
+        } catch (Exception e) {
+            throw new RuntimeException("Critical: Failed to load revocation data", e);
         }
     }
 
@@ -142,9 +169,22 @@ public record RevocationList(String status, String reason) {
         return publishTime;
     }
 
+    public static DataSource getCurrentSource() {
+        return currentSource;
+    }
+
     public static void refresh() {
         synchronized (RevocationList.class) {
-            data = getStatus();
+            StatusResult result = getStatus();
+            data = result.json();
+            
+            // If we successfully fetched a brand new file this session, 
+            // don't let a subsequent UI refresh overwrite our status with a 304!
+            if (currentSource == DataSource.NETWORK_UPDATE && result.source() == DataSource.NETWORK_UP_TO_DATE) {
+                Log.i(TAG, "Preserving NETWORK_UPDATE status across multiple refreshes");
+            } else {
+                currentSource = result.source();
+            }
         }
     }
 
@@ -152,28 +192,28 @@ public record RevocationList(String status, String reason) {
         if (data == null) {
             synchronized (RevocationList.class) {
                 if (data == null) {
-                    data = getStatus();
+                    StatusResult result = getStatus();
+                    data = result.json();
+                    
+                    if (currentSource == DataSource.NETWORK_UPDATE && result.source() == DataSource.NETWORK_UP_TO_DATE) {
+                        Log.i(TAG, "Preserving NETWORK_UPDATE status in get()");
+                    } else {
+                        currentSource = result.source();
+                    }
                 }
             }
         }
-        String serialNumberString = serialNumber.toString(16).toLowerCase();
-        JSONObject revocationStatus;
+        String serial = serialNumber.toString(16).toLowerCase();
         try {
-            revocationStatus = data.getJSONObject(serialNumberString);
+            JSONObject entry = data.getJSONObject(serial);
+            return new RevocationList(entry.getString("status"), entry.getString("reason"), currentSource);
         } catch (JSONException e) {
             return null;
-        }
-        try {
-            var status = revocationStatus.getString("status");
-            var reason = revocationStatus.getString("reason");
-            return new RevocationList(status, reason);
-        } catch (JSONException e) {
-            return new RevocationList("", "");
         }
     }
 
     @Override
     public String toString() {
-        return "status is " + status + ", reason is " + reason;
+        return "status: " + status + ", source: " + source;
     }
 }

--- a/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeAdapter.kt
+++ b/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeAdapter.kt
@@ -94,17 +94,33 @@ class HomeAdapter(listener: Listener) : IdBasedRecyclerViewAdapter() {
             addItem(CommonItemViewHolder.CERT_INFO_CREATOR, certInfo, id++)
         }
 
-        // Add revocation list information
+        // Add revocation list information with source status
         val publishTime = io.github.vvb2060.keyattestation.attestation.RevocationList.getPublishTime()
-        val dateStr = if (publishTime != null) {
-            io.github.vvb2060.keyattestation.attestation.AuthorizationList.formatDate(publishTime)
-        } else {
-            null
+        val source = io.github.vvb2060.keyattestation.attestation.RevocationList.getCurrentSource()
+        val app = io.github.vvb2060.keyattestation.AppApplication.app
+
+        val dateStr = publishTime?.let {
+            io.github.vvb2060.keyattestation.attestation.AuthorizationList.formatDate(it)
+        } ?: ""
+
+        val statusLine = when (source) {
+            RevocationList.DataSource.NETWORK_UPDATE -> app.getString(R.string.revocation_status_new_fetch)
+            RevocationList.DataSource.NETWORK_UP_TO_DATE -> app.getString(R.string.revocation_status_up_to_date)
+            RevocationList.DataSource.CACHE -> app.getString(R.string.revocation_status_offline_cached)
+            RevocationList.DataSource.BUNDLED -> app.getString(R.string.revocation_status_offline_bundled)
+            else -> ""
         }
+
+        val dateDisplay = if (dateStr.isNotEmpty()) {
+            "$dateStr\n$statusLine"
+        } else {
+            statusLine
+        }.trim().ifEmpty { null }
+
         addItem(CommonItemViewHolder.COMMON_CREATOR, CommonData(
                 R.string.revocation_list_publish_time,
                 R.string.revocation_list_description,
-                dateStr), ID_REVOCATION_INFO)
+                dateDisplay), ID_REVOCATION_INFO)
 
         when (baseData) {
             is AttestationData -> updateData(baseData)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,11 @@
     <string name="provisioning_info_manufacturer">manufacturer: </string>
     <string name="revocation_list_publish_time">Revocation list publish time</string>
     <string name="revocation_list_description">The revocation list is used to check if certificates have been revoked. This shows the publication time of the currently used revocation list.</string>
+    
+    <string name="revocation_status_new_fetch">ℹ️ New CRL Fetched!</string>
+    <string name="revocation_status_up_to_date">✅ CRL Up-to-date</string>
+    <string name="revocation_status_offline_cached">⚠️ Device offline - using cached CRL</string>
+    <string name="revocation_status_offline_bundled">❌ Offline - using hardcoded 27th Feb CRL</string>
 
     <string name="error_message_subtitle">Detailed messages:</string>
     <string name="error_unknown">Unknown error</string>


### PR DESCRIPTION
This PR introduces a more descriptive and optimized way to handle and display Certificate Revocation List (CRL) data to the user.
​Key Changes:
​Bandwidth Optimization (RevocationList.java): Implemented an If-Modified-Since header check using the cached publish time. If the Google server responds with HTTP 304 Not Modified, the app safely reuses the cache, saving bandwidth and speeding up the launch.
​State Tracking (RevocationList.java): Introduced a DataSource enum (NETWORK_UPDATE, NETWORK_UP_TO_DATE, CACHE, BUNDLED) to accurately track exactly where the active CRL data originated. Added synchronization logic to prevent background UI refreshes from accidentally overwriting a "new fetch" state with a 304 state during the same session.
​UI Cleanup (CertificateInfo.java): Removed the redundant "cached" and "offline" suffixes from the CertificateException messages. The certificate chain UI now cleanly displays revoked:REVOKED, eliminating awkward text wrapping and UI clutter.
​Enhanced Revocation Card (HomeAdapter.kt & strings.xml): Piped the new DataSource states into the Revocation List publish time card. Users now get immediate, icon-driven feedback on their network state:
​ℹ️ New CRL Fetched!
​✅ CRL Up-to-date
​⚠️ Device offline - using cached CRL
​❌ Offline - using hardcoded [Date] CRL