### PR TITLE
Update bundled CRL to latest Google status

### DIFF
--- a/app/src/main/java/io/github/vvb2060/keyattestation/attestation/RevocationList.java
+++ b/app/src/main/java/io/github/vvb2060/keyattestation/attestation/RevocationList.java
@@ -129,23 +129,41 @@ public record RevocationList(String status, String reason, DataSource source) {
         
         // 1. Network Check
         NetworkResult networkResult = fetchFromNetwork(statusUrl, cachedTime);
-        if (networkResult != null) {
-            if (networkResult.responseCode() == HttpURLConnection.HTTP_NOT_MODIFIED) {
-                try (var fis = AppApplication.app.openFileInput(CACHE_FILE)) {
-                    var cacheJson = parseStatus(fis);
-                    publishTime = new Date(cachedTime);
-                    return new StatusResult(cacheJson.getJSONObject("entries"), DataSource.NETWORK_UP_TO_DATE);
-                } catch (Exception e) {
-                    Log.w(TAG, "Failed to read cache despite 304 response. Falling back.", e);
-                }
-            } else if (networkResult.json() != null) {
-                saveToCache(networkResult.json());
-                try {
-                    return new StatusResult(networkResult.json().getJSONObject("entries"), DataSource.NETWORK_UPDATE);
-                } catch (JSONException ignored) {}
-            }
-        }
         
+        if (networkResult != null && networkResult.responseCode() == HttpURLConnection.HTTP_NOT_MODIFIED) {
+            try (var fis = AppApplication.app.openFileInput(CACHE_FILE)) {
+                var cacheJson = parseStatus(fis);
+                publishTime = new Date(cachedTime);
+                return new StatusResult(cacheJson.getJSONObject("entries"), DataSource.NETWORK_UP_TO_DATE);
+            } catch (Exception e) {
+                Log.w(TAG, "Legacy cache format detected. Clearing and forcing fresh fetch.", e);
+                
+                // 1. Wipe the old, incompatible cache file
+                AppApplication.app.deleteFile(CACHE_FILE);
+                
+                // 2. Wipe the saved timestamp so we don't send If-Modified-Since again
+                prefs.edit().remove(KEY_PUBLISH_TIME).apply();
+                
+                // 3. Immediately force a fresh 200 OK download
+                NetworkResult retryResult = fetchFromNetwork(statusUrl, 0);
+                
+                if (retryResult != null && retryResult.json() != null) {
+                    saveToCache(retryResult.json()); 
+                    
+                    try {
+                        return new StatusResult(retryResult.json().getJSONObject("entries"), DataSource.NETWORK_UPDATE);
+                    } catch (JSONException je) {
+                        Log.e(TAG, "Failed to parse entries from fresh fallback fetch", je);
+                    }
+                }
+            }
+        } else if (networkResult != null && networkResult.json() != null) {
+            saveToCache(networkResult.json());
+            try {
+                return new StatusResult(networkResult.json().getJSONObject("entries"), DataSource.NETWORK_UPDATE);
+            } catch (JSONException ignored) {}
+        }
+
         // 2. Cache
         try (var fis = AppApplication.app.openFileInput(CACHE_FILE)) {
             var cacheJson = parseStatus(fis);

--- a/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeAdapter.kt
+++ b/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeAdapter.kt
@@ -102,8 +102,7 @@ class HomeAdapter(listener: Listener) : IdBasedRecyclerViewAdapter() {
         val dateStr = publishTime?.let {
             io.github.vvb2060.keyattestation.attestation.AuthorizationList.formatDate(it)
         } ?: ""
-
-        val app = io.github.vvb2060.keyattestation.AppApplication.app
+        
         val locales = androidx.appcompat.app.AppCompatDelegate.getApplicationLocales()
         val context = if (!locales.isEmpty) {
         val config = android.content.res.Configuration(app.resources.configuration)

--- a/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeAdapter.kt
+++ b/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeAdapter.kt
@@ -103,11 +103,21 @@ class HomeAdapter(listener: Listener) : IdBasedRecyclerViewAdapter() {
             io.github.vvb2060.keyattestation.attestation.AuthorizationList.formatDate(it)
         } ?: ""
 
+        val app = io.github.vvb2060.keyattestation.AppApplication.app
+        val locales = androidx.appcompat.app.AppCompatDelegate.getApplicationLocales()
+        val context = if (!locales.isEmpty) {
+        val config = android.content.res.Configuration(app.resources.configuration)
+            config.setLocale(locales[0])
+            app.createConfigurationContext(config)
+        } else {
+            app
+        }       
+        
         val statusLine = when (source) {
-            RevocationList.DataSource.NETWORK_UPDATE -> app.getString(R.string.revocation_status_new_fetch)
-            RevocationList.DataSource.NETWORK_UP_TO_DATE -> app.getString(R.string.revocation_status_up_to_date)
-            RevocationList.DataSource.CACHE -> app.getString(R.string.revocation_status_offline_cached)
-            RevocationList.DataSource.BUNDLED -> app.getString(R.string.revocation_status_offline_bundled)
+            RevocationList.DataSource.NETWORK_UPDATE -> context.getString(R.string.revocation_status_new_fetch)
+            RevocationList.DataSource.NETWORK_UP_TO_DATE -> context.getString(R.string.revocation_status_up_to_date)
+            RevocationList.DataSource.CACHE -> context.getString(R.string.revocation_status_offline_cached)
+            RevocationList.DataSource.BUNDLED -> context.getString(R.string.revocation_status_offline_bundled)
             else -> ""
         }
 

--- a/app/src/main/res/raw/status.json
+++ b/app/src/main/res/raw/status.json
@@ -1,30 +1,30 @@
 {
   "entries": {
-    "6681152659205225093" : {
+    "6681152659205225093": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "8350192447815228107" : {
+    "8350192447815228107": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "9408173275444922801" : {
+    "9408173275444922801": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "11244410301401252959" : {
+    "11244410301401252959": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "15346629759498347257" : {
+    "15346629759498347257": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "1228286566665971148" : {
+    "1228286566665971148": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "17471682139930361099" : {
+    "17471682139930361099": {
       "status": "REVOKED",
       "reason": "SOFTWARE_FLAW"
     },
@@ -68,311 +68,311 @@
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "1476c32be5b4788386062ca1d6a3ec01" : {
+    "1476c32be5b4788386062ca1d6a3ec01": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "c9b95f08cb46c66e778a996bb04eb063" : {
+    "c9b95f08cb46c66e778a996bb04eb063": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "2775678662643671941" : {
+    "2775678662643671941": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "10478051501886118140" : {
+    "10478051501886118140": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "15304424745846567057" : {
+    "15304424745846567057": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "2540354691047989632" : {
+    "2540354691047989632": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "9605027729693255932" : {
+    "9605027729693255932": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "7266970422002561562" : {
+    "7266970422002561562": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "2121480040206509646" : {
+    "2121480040206509646": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "4722071905782261079" : {
+    "4722071905782261079": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "13791718860221210775" : {
+    "13791718860221210775": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "5318853256439367328" : {
+    "5318853256439367328": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "16619986970074733637" : {
+    "16619986970074733637": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "8090691296252605665" : {
+    "8090691296252605665": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "9422579570321443809" : {
+    "9422579570321443809": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "14441488828221950432" : {
+    "14441488828221950432": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "cfd09f492467a8d78f3c87f8ae82b0ed" : {
+    "cfd09f492467a8d78f3c87f8ae82b0ed": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "843184b4161e8dfbb711061d3483ad81" : {
+    "843184b4161e8dfbb711061d3483ad81": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "f2e14b3039c35d54fb9661b60b17ec94" : {
+    "f2e14b3039c35d54fb9661b60b17ec94": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "836d1498921ff86a22fe3768042849a2" : {
+    "836d1498921ff86a22fe3768042849a2": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "c95180267ba53a50b636e36d32976065" : {
+    "c95180267ba53a50b636e36d32976065": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "9414602a0ce3f77d9ac05af532785ef" : {
+    "9414602a0ce3f77d9ac05af532785ef": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "c21b00ddf8c5a26106a03e8c11b37998" : {
+    "c21b00ddf8c5a26106a03e8c11b37998": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "d9e9fa3c6021bcca273b524f551feab9" : {
+    "d9e9fa3c6021bcca273b524f551feab9": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "6a0c9ef31f814ebb8d8301eb443f7940" : {
+    "6a0c9ef31f814ebb8d8301eb443f7940": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "78d6b0810af9e6897b62ef2e26a853d2" : {
+    "78d6b0810af9e6897b62ef2e26a853d2": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "e8063fd19d678b46998c5d25bf6bcd2" : {
+    "e8063fd19d678b46998c5d25bf6bcd2": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "a23891b8cf1e06bea42599aecd9bc9cf" : {
+    "a23891b8cf1e06bea42599aecd9bc9cf": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "fc609574570c3e0a1d347e02a2ad6d4d" : {
+    "fc609574570c3e0a1d347e02a2ad6d4d": {
       "status": "REVOKED",
       "reason": "SOFTWARE_FLAW"
     },
-    "7355273169128314967" : {
+    "7355273169128314967": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "5344612975616013951" : {
+    "5344612975616013951": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "16166206677093325219" : {
+    "16166206677093325219": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "15489222854939603791" : {
+    "15489222854939603791": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "18154252358500841010" : {
+    "18154252358500841010": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "12098947777634431853" : {
+    "12098947777634431853": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "10997554208317698753" : {
+    "10997554208317698753": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "12365028775357944392" : {
+    "12365028775357944392": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "3bbbbd83aa163125a86e900730bc9f53" : {
+    "3bbbbd83aa163125a86e900730bc9f53": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "fb3b56606adc45049dd5ebc0846e0daf" : {
+    "fb3b56606adc45049dd5ebc0846e0daf": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "90fdc81863091e2bc62519d620143d1" : {
+    "90fdc81863091e2bc62519d620143d1": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "1ae2ba1ba985e8a55a3b617172e61537" : {
+    "1ae2ba1ba985e8a55a3b617172e61537": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "7f69b2f66b0679f7fffc721fc3978128" : {
+    "7f69b2f66b0679f7fffc721fc3978128": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "4b7f33db15d04ce1736768dbad021261" : {
+    "4b7f33db15d04ce1736768dbad021261": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "43cf4aa6e5d9744dd436d9d5ef1391cd" : {
+    "43cf4aa6e5d9744dd436d9d5ef1391cd": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "ad3b740cccc9369f89240dbc5284cb10" : {
+    "ad3b740cccc9369f89240dbc5284cb10": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "9ed21fe7bfa899183bcb0833de8c5178" : {
+    "9ed21fe7bfa899183bcb0833de8c5178": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "87a5a6991dfa390d3e4c61bbe3d291b3" : {
+    "87a5a6991dfa390d3e4c61bbe3d291b3": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "fb5adea0f8212f845bea3f996bcee726" : {
+    "fb5adea0f8212f845bea3f996bcee726": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "7f90e587a2cb6ef5dee0b83b58893d74" : {
+    "7f90e587a2cb6ef5dee0b83b58893d74": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "6b870bcad63bdfe92d02ba4698b16264" : {
+    "6b870bcad63bdfe92d02ba4698b16264": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "1af3b8c5427453b6937ae0bcb6fe447f" : {
+    "1af3b8c5427453b6937ae0bcb6fe447f": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "2975e3f59a67e034d4bd451b927f1d27" : {
+    "2975e3f59a67e034d4bd451b927f1d27": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "cdee0d31cb8400838344756231940aea" : {
+    "cdee0d31cb8400838344756231940aea": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "c578cd2e254c12dff8ee2ac82f93410a" : {
+    "c578cd2e254c12dff8ee2ac82f93410a": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "e7daf1046d38581b22f1dd7946b15f1" : {
+    "e7daf1046d38581b22f1dd7946b15f1": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "8d76fce4395906995adf0de84b80e2ec" : {
+    "8d76fce4395906995adf0de84b80e2ec": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "82d779713c8ee285e8a7ffd61cbfb7ed" : {
+    "82d779713c8ee285e8a7ffd61cbfb7ed": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "fc0a3c9f31721c524c3bd84afa72cbe3" : {
+    "fc0a3c9f31721c524c3bd84afa72cbe3": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "b8ac6e0771a0958aeaa4b68a111a5dee" : {
+    "b8ac6e0771a0958aeaa4b68a111a5dee": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "94f4943f978b93b4d7f4e69dc20b4d6b" : {
+    "94f4943f978b93b4d7f4e69dc20b4d6b": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "c39c08de9731fd57d124c3e17c53faca" : {
+    "c39c08de9731fd57d124c3e17c53faca": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "e24e5301403dcb9bad30918083fa15c7" : {
+    "e24e5301403dcb9bad30918083fa15c7": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "dfd704581cbf9fe223b5c351fab83b4e" : {
+    "dfd704581cbf9fe223b5c351fab83b4e": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "dfd0bf6bb1cb606ef65572412c0d1ac8" : {
+    "dfd0bf6bb1cb606ef65572412c0d1ac8": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "4d818d8a042b22646a42c395e5c86d6" : {
+    "4d818d8a042b22646a42c395e5c86d6": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "7f9ec229afd8185d8432f408108e0991" : {
+    "7f9ec229afd8185d8432f408108e0991": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "846736b71487a74075ed6f33f58e4b33" : {
+    "846736b71487a74075ed6f33f58e4b33": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "14e38b3979edef06d0e95b7131a08b22" : {
+    "14e38b3979edef06d0e95b7131a08b22": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "c2272cf25f9ccac5b5633a36b5e08fa9" : {
+    "c2272cf25f9ccac5b5633a36b5e08fa9": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "8868809403284598250" : {
+    "8868809403284598250": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "15443728027744674372" : {
+    "15443728027744674372": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "224403031710863989" : {
+    "224403031710863989": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "3882667606589968590" : {
+    "3882667606589968590": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "8398415515671998339" : {
+    "8398415515671998339": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "13965740041072508681" : {
+    "13965740041072508681": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "70771aada0054842160ef0764bce1623" : {
+    "70771aada0054842160ef0764bce1623": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
-    "119e72132a781e012ce7a8e68533b140" : {
+    "119e72132a781e012ce7a8e68533b140": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     },
@@ -6549,6 +6549,14 @@
       "reason": "KEY_COMPROMISE"
     },
     "8fac374efe9ac6ca59334e658750c91b": {
+      "status": "REVOKED",
+      "reason": "KEY_COMPROMISE"
+    },
+    "7d9fb9f1ffa2825e559fa61ceb80ea8a": {
+      "status": "REVOKED",
+      "reason": "KEY_COMPROMISE"
+    },
+    "4d12fb192418eee5a947c0d70ab006d7": {
       "status": "REVOKED",
       "reason": "KEY_COMPROMISE"
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,7 +60,7 @@
     <string name="revocation_status_new_fetch">ℹ️ New CRL Fetched!</string>
     <string name="revocation_status_up_to_date">✅ CRL Up-to-date</string>
     <string name="revocation_status_offline_cached">⚠️ Device offline - using cached CRL</string>
-    <string name="revocation_status_offline_bundled">❌ Offline - using hardcoded 27th Feb CRL</string>
+    <string name="revocation_status_offline_bundled">❌ Offline - using hardcoded 17th March CRL</string>
 
     <string name="error_message_subtitle">Detailed messages:</string>
     <string name="error_unknown">Unknown error</string>


### PR DESCRIPTION
Updates the hardcoded offline fallback status.json to the latest payload from Google and bumps the UI badge string to reflect the March 17th date.