### PR TITLE
feat: overhaul dynamic CRL fetch logic and enhance status UI

### DIFF
--- a/app/src/main/java/io/github/vvb2060/keyattestation/attestation/AuthorizationList.java
+++ b/app/src/main/java/io/github/vvb2060/keyattestation/attestation/AuthorizationList.java
@@ -532,8 +532,10 @@ public class AuthorizationList {
     }
 
     public static String formatDate(Date date) {
-        return DateFormat.getDateTimeInstance().format(date);
-    }
+        java.text.DateFormat df = java.text.DateFormat.getDateTimeInstance();
+        df.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+        return df.format(date) + " UTC";
+    }    
 
     public static String paddingModesToString(final Set<Integer> paddingModes) {
         return joinStrings(transform(paddingModes, forMap(paddingMap, "Unknown")));

--- a/app/src/main/java/io/github/vvb2060/keyattestation/attestation/RevocationList.java
+++ b/app/src/main/java/io/github/vvb2060/keyattestation/attestation/RevocationList.java
@@ -21,13 +21,14 @@ import io.github.vvb2060.keyattestation.AppApplication;
 import io.github.vvb2060.keyattestation.R;
 
 public record RevocationList(String status, String reason, DataSource source) {
-    public enum DataSource {
+	public enum DataSource {
+        NETWORK_INITIAL,
         NETWORK_UPDATE,
         NETWORK_UP_TO_DATE,
         CACHE,
         BUNDLED
     }
-
+    
     private static final String TAG = "RevocationList";
     private static final String CACHE_FILE = "revocation_cache.json";
     private static final String PREFS_NAME = "revocation_prefs";
@@ -83,6 +84,15 @@ public record RevocationList(String status, String reason, DataSource source) {
             connection.setReadTimeout(10000);
             connection.setRequestProperty("User-Agent", "KeyAttestation");
             
+            double rand = Math.round(Math.random() * 1000.0) / 1000.0;
+            
+            // Force the CDN to bypass edge caches
+            connection.setRequestProperty("Cache-Control", "no-cache, no-store, no-transform, max-age=0");
+            connection.setRequestProperty("Accept", "application/json, */*;q=" + rand);
+            connection.setRequestProperty("Accept-Encoding", "identity, *;q=" + rand);
+            connection.setRequestProperty("Accept-Ranges", "bytes");
+            
+            // Standard conditional GET for bandwidth saving (if the node IS synced)
             if (cachedTime != 0) {
                 connection.setIfModifiedSince(cachedTime);
             }
@@ -160,7 +170,8 @@ public record RevocationList(String status, String reason, DataSource source) {
         } else if (networkResult != null && networkResult.json() != null) {
             saveToCache(networkResult.json());
             try {
-                return new StatusResult(networkResult.json().getJSONObject("entries"), DataSource.NETWORK_UPDATE);
+                DataSource successState = (cachedTime == 0) ? DataSource.NETWORK_INITIAL : DataSource.NETWORK_UPDATE;
+                return new StatusResult(networkResult.json().getJSONObject("entries"), successState);
             } catch (JSONException ignored) {}
         }
 
@@ -198,7 +209,7 @@ public record RevocationList(String status, String reason, DataSource source) {
             
             // If we successfully fetched a brand new file this session, 
             // don't let a subsequent UI refresh overwrite our status with a 304!
-            if (currentSource == DataSource.NETWORK_UPDATE && result.source() == DataSource.NETWORK_UP_TO_DATE) {
+            if ((currentSource == DataSource.NETWORK_UPDATE || currentSource == DataSource.NETWORK_INITIAL) && result.source() == DataSource.NETWORK_UP_TO_DATE) {
                 Log.i(TAG, "Preserving NETWORK_UPDATE status across multiple refreshes");
             } else {
                 currentSource = result.source();
@@ -213,7 +224,7 @@ public record RevocationList(String status, String reason, DataSource source) {
                     StatusResult result = getStatus();
                     data = result.json();
                     
-                    if (currentSource == DataSource.NETWORK_UPDATE && result.source() == DataSource.NETWORK_UP_TO_DATE) {
+                    if ((currentSource == DataSource.NETWORK_UPDATE || currentSource == DataSource.NETWORK_INITIAL) && result.source() == DataSource.NETWORK_UP_TO_DATE) {
                         Log.i(TAG, "Preserving NETWORK_UPDATE status in get()");
                     } else {
                         currentSource = result.source();

--- a/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeAdapter.kt
+++ b/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeAdapter.kt
@@ -113,6 +113,7 @@ class HomeAdapter(listener: Listener) : IdBasedRecyclerViewAdapter() {
         }       
         
         val statusLine = when (source) {
+            RevocationList.DataSource.NETWORK_INITIAL -> context.getString(R.string.revocation_status_initial)
             RevocationList.DataSource.NETWORK_UPDATE -> context.getString(R.string.revocation_status_new_fetch)
             RevocationList.DataSource.NETWORK_UP_TO_DATE -> context.getString(R.string.revocation_status_up_to_date)
             RevocationList.DataSource.CACHE -> context.getString(R.string.revocation_status_offline_cached)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,8 @@
     <string name="revocation_list_publish_time">Revocation list publish time</string>
     <string name="revocation_list_description">The revocation list is used to check if certificates have been revoked. This shows the publication time of the currently used revocation list.</string>
     
-    <string name="revocation_status_new_fetch">ℹ️ New CRL Fetched!</string>
+    <string name="revocation_status_initial">⚙️ Initial list downloaded</string>
+    <string name="revocation_status_new_fetch">✨ New list fetched!</string>
     <string name="revocation_status_up_to_date">✅ CRL Up-to-date</string>
     <string name="revocation_status_offline_cached">⚠️ Device offline - using cached CRL</string>
     <string name="revocation_status_offline_bundled">❌ Offline - CRL Out-of-date</string>


### PR DESCRIPTION
- Network: Implemented a dynamic cache-busting strategy using randomized floats and 'identity' encoding in HTTP headers. This bypasses aggressive Google CDN edge caching (stale HTTP 200s / 304s) to guarantee fetching the absolute latest X.509 revocation list directly from the origin server.

- UI: Introduced dual-badge CRL update logic, splitting the network state strings into granular 'Initial list downloaded' and 'New list fetched' states for clearer user feedback.

- Formatting: Locked the CRL publish time display in AuthorizationList to strict GMT/UTC to eliminate local timezone ambiguity.

Credits:

- CDN cache-busting header logic courtesy of XDA members TheFreeman193 and Vagelis1608.

- New strings 
<img width="783" height="246" alt="Screenshot_20260403-155646" src="https://github.com/user-attachments/assets/28c288d2-1cc0-4113-835f-94ed064a3096" />


<img width="864" height="1872" alt="Screenshot_20260403-154217" src="https://github.com/user-attachments/assets/f5d8f088-439f-421d-b14b-7cfb56ae4b29" />
